### PR TITLE
Fix bare locale 404 (eg redirect from /en to /en/home) and invalid image on 404 page.

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -33,6 +33,8 @@ const NotFound = () => {
                 loading="lazy"
                 alt="A person stands behind a red-tinted, foggy surface with hands pressed against it, wearing a cap and jacket."
                 className="absolute inset-0 h-full w-full object-cover object-center"
+                width={600}
+                height={752}
               />
             </div>
           </div>

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,23 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**'
+      }
     ],
+  },
+  async redirects() {
+    return [
+      // Redirect bare locale to /home to prevent accidental 404s
+      {
+        source: '/:lng',
+        destination: '/:lng/home',
+        permanent: true,
+      },
+    ]
   },
 };
 


### PR DESCRIPTION
## Before

A bare locale like `/en` was resulting in a 404:
<img width="1734" height="1336" alt="Mozilla Firefox - 2025-10-15 02-54-17 PM" src="https://github.com/user-attachments/assets/9cdaf693-072b-4fa1-98c3-7764962ba469" />

Additionally, the image on that 404 page was invalid because it was missing `width` and `height`, and Unsplash was not an allowed image source in `next.config.js`.

## After
The bare locale automatically redirects to /home
<img width="3372" height="1846" alt="Ecommerce Page Demonstration - 2025-10-15 02-55-12 PM" src="https://github.com/user-attachments/assets/b63703a4-1602-4de6-9b84-0220371ad38b" />

404 page image correctly loads:
<img width="3282" height="1850" alt="Mozilla Firefox - 2025-10-15 02-55-38 PM" src="https://github.com/user-attachments/assets/e6c99e0f-3a2b-44b7-9616-c40cdb1edbb6" />
