### PR TITLE
Fix open redirects in ecommerce-website-demo draft-mode handlers

### DIFF
--- a/app/api/draft/disable/route.tsx
+++ b/app/api/draft/disable/route.tsx
@@ -1,8 +1,10 @@
 import { cookies, draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { isSafeRedirectUrl } from '@/utils/isSafeRedirectUrl';
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
+  const requestUrl = new URL(request.url);
+  const { searchParams } = requestUrl;
 
   const url = searchParams.get('redirect');
 
@@ -10,6 +12,9 @@ export async function GET(request: Request) {
   draft.disable();
 
   if (!url) return new Response('Draft mode is disabled');
+
+  if (!isSafeRedirectUrl(url, requestUrl))
+    return new Response('URL must be relative!', { status: 422 });
 
   //to avoid losing the cookie on redirect in the iFrame
   const cookieStore = await cookies();

--- a/app/api/draft/enable/route.tsx
+++ b/app/api/draft/enable/route.tsx
@@ -1,9 +1,11 @@
 import { cookies, draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { NextRequest } from 'next/server';
+import { isSafeRedirectUrl } from '@/utils/isSafeRedirectUrl';
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
+  const requestUrl = new URL(request.url);
+  const { searchParams } = requestUrl;
 
   const token = searchParams.get('token');
   const url = searchParams.get('redirect');
@@ -15,6 +17,9 @@ export async function GET(request: NextRequest) {
   draft.enable();
 
   if (!url) return new Response('Draft mode is enabled');
+
+  if (!isSafeRedirectUrl(url, requestUrl))
+    return new Response('URL must be relative!', { status: 422 });
 
   //to avoid losing the cookie on redirect in the iFrame
   const cookieStore = await cookies();

--- a/utils/isSafeRedirectUrl.ts
+++ b/utils/isSafeRedirectUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * Determine whether a user-supplied redirect target is safe to follow — i.e. it
+ * points to the same host as the current request.
+ *
+ * This guards against open-redirect attacks. A naive `url.startsWith('http')`
+ * check — and even a plain "is it a relative URL?" check — fails to catch
+ * protocol-relative targets like `//evil.com` or backslash variants like
+ * `/\evil.com`, both of which browsers happily send off-site.
+ *
+ * Instead, we resolve the candidate against the current request URL and require
+ * the resulting hostname to match. Relative paths (`/foo`, `/a?b=1#c`) resolve
+ * to the same host and pass; anything that escapes to another host — or fails to
+ * parse — is rejected. The scheme is irrelevant: we only compare hostnames.
+ */
+export function isSafeRedirectUrl(candidate: string, requestUrl: URL): boolean {
+  try {
+    const target = new URL(candidate, requestUrl);
+    return target.hostname === requestUrl.hostname;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Validate the user-supplied ?redirect param in the draft enable/disable route handlers against an open-redirect attack. Both handlers previously passed the param straight to redirect(), letting a crafted link on our domain bounce victims to an arbitrary host (the unauthenticated disable handler being the more exposed).

Add a shared isSafeRedirectUrl(candidate, requestUrl) helper that resolves the candidate against the request URL and accepts it only when the resolved hostname matches. This rejects protocol-relative (//evil.com), backslash, uppercase-scheme and whitespace bypasses that startsWith/relative checks miss, while allowing genuine same-host and relative targets.